### PR TITLE
Add Essentials-based home GUI plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
 # HomeSystem
+
+Ein schlankes Bukkit/Spigot Plugin, das die Homes aus EssentialsX in einem benutzerfreundlichen GUI darstellt. Spieler können mit `/home` oder `/homes` ihre Homes als Menü öffnen und werden durch Anklicken sofort teleportiert.
+
+## Features
+
+- Nutzt die bestehenden Homes aus EssentialsX – keine doppelte Datenhaltung.
+- Öffnet per `/home` oder `/homes` ein Inventar mit allen verfügbaren Homes.
+- Teleportiert den Spieler beim Anklicken eines Items direkt zum ausgewählten Home.
+- Verhindert das Herausnehmen, Verschieben oder Droppen der Items innerhalb des Menüs.
+- Unterstützt bis zu 54 Homes gleichzeitig (weitere Homes werden nicht angezeigt).
+
+## Installation
+
+1. Lade das fertige Plugin (JAR) per `mvn package`.
+2. Lege die JAR-Datei in den `plugins`-Ordner deines Spigot/Paper Servers.
+3. Stelle sicher, dass [EssentialsX](https://essentialsx.net/) installiert ist.
+4. Starte den Server neu oder führe `/reload confirm` aus.
+
+## Benutzung
+
+- `/home` – Öffnet das Menü mit allen Homes.
+- `/homes` – Alias für `/home`.
+
+## Entwicklung
+
+Dieses Projekt nutzt Maven. Die wichtigsten Befehle:
+
+```bash
+mvn clean package
+```
+
+Die Abhängigkeiten `spigot-api` und `Essentials` werden als `provided` markiert und müssen zur Laufzeit auf dem Server vorhanden sein.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,71 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>de.example</groupId>
+    <artifactId>HomeSystem</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <name>HomeSystem</name>
+    <description>GUI based home selector that uses EssentialsX homes.</description>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>spigot-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+        </repository>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>1.20.4-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.EssentialsX</groupId>
+            <artifactId>Essentials</artifactId>
+            <version>2.20.1</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <release>17</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.4.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/de/example/homesystem/HomeCommand.java
+++ b/src/main/java/de/example/homesystem/HomeCommand.java
@@ -1,0 +1,36 @@
+package de.example.homesystem;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+import java.util.List;
+
+public class HomeCommand implements CommandExecutor, TabCompleter {
+
+    private final HomeViewManager viewManager;
+
+    public HomeCommand(HomeViewManager viewManager) {
+        this.viewManager = viewManager;
+    }
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("§cNur Spieler können diesen Befehl nutzen.");
+            return true;
+        }
+
+        viewManager.openHomeMenu(player);
+        return true;
+    }
+
+    @Override
+    public @NotNull List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String alias, @NotNull String[] args) {
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/de/example/homesystem/HomeMenuListener.java
+++ b/src/main/java/de/example/homesystem/HomeMenuListener.java
@@ -1,0 +1,64 @@
+package de.example.homesystem;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
+import org.bukkit.event.player.PlayerDropItemEvent;
+
+public class HomeMenuListener implements Listener {
+
+    private final HomeViewManager viewManager;
+
+    public HomeMenuListener(HomeViewManager viewManager) {
+        this.viewManager = viewManager;
+    }
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+
+        if (!viewManager.isHomeMenu(player, event.getView().getTopInventory())) {
+            return;
+        }
+
+        event.setCancelled(true);
+
+        if (event.getClickedInventory() == null || !event.getView().getTopInventory().equals(event.getClickedInventory())) {
+            return;
+        }
+
+        viewManager.handleMenuClick(player, event.getSlot());
+    }
+
+    @EventHandler
+    public void onInventoryDrag(InventoryDragEvent event) {
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+
+        if (viewManager.isHomeMenu(player, event.getView().getTopInventory())) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onInventoryClose(InventoryCloseEvent event) {
+        if (event.getPlayer() instanceof Player player) {
+            viewManager.closeMenu(player);
+        }
+    }
+
+    @EventHandler
+    public void onItemDrop(PlayerDropItemEvent event) {
+        Player player = event.getPlayer();
+        if (player.getOpenInventory() != null &&
+                viewManager.isHomeMenu(player, player.getOpenInventory().getTopInventory())) {
+            event.setCancelled(true);
+        }
+    }
+}

--- a/src/main/java/de/example/homesystem/HomeSystemPlugin.java
+++ b/src/main/java/de/example/homesystem/HomeSystemPlugin.java
@@ -1,0 +1,54 @@
+package de.example.homesystem;
+
+import com.earth2me.essentials.Essentials;
+import org.bukkit.Bukkit;
+import org.bukkit.command.PluginCommand;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.logging.Level;
+
+public class HomeSystemPlugin extends JavaPlugin {
+
+    private Essentials essentials;
+    private HomeViewManager viewManager;
+
+    @Override
+    public void onEnable() {
+        Plugin essentialsPlugin = getServer().getPluginManager().getPlugin("Essentials");
+        if (!(essentialsPlugin instanceof Essentials)) {
+            getLogger().log(Level.SEVERE, "EssentialsX konnte nicht gefunden werden. Bitte installiere EssentialsX.");
+            getServer().getPluginManager().disablePlugin(this);
+            return;
+        }
+        this.essentials = (Essentials) essentialsPlugin;
+
+        this.viewManager = new HomeViewManager(essentials);
+
+        HomeCommand homeCommand = new HomeCommand(viewManager);
+        registerCommand("home", homeCommand);
+        registerCommand("homes", homeCommand);
+
+        Bukkit.getPluginManager().registerEvents(new HomeMenuListener(viewManager), this);
+
+        getLogger().info("HomeSystem wurde erfolgreich aktiviert.");
+    }
+
+    private void registerCommand(String name, HomeCommand executor) {
+        PluginCommand command = getCommand(name);
+        if (command == null) {
+            getLogger().log(Level.SEVERE, "Befehl /" + name + " konnte nicht registriert werden.");
+            return;
+        }
+        command.setExecutor(executor);
+        command.setTabCompleter(executor);
+    }
+
+    public Essentials getEssentials() {
+        return essentials;
+    }
+
+    public HomeViewManager getViewManager() {
+        return viewManager;
+    }
+}

--- a/src/main/java/de/example/homesystem/HomeViewManager.java
+++ b/src/main/java/de/example/homesystem/HomeViewManager.java
@@ -1,0 +1,133 @@
+package de.example.homesystem;
+
+import com.earth2me.essentials.Essentials;
+import com.earth2me.essentials.User;
+import net.ess3.api.InvalidWorldException;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+public class HomeViewManager {
+
+    private final Essentials essentials;
+    private final Map<UUID, Inventory> openMenus = new HashMap<>();
+
+    public HomeViewManager(Essentials essentials) {
+        this.essentials = essentials;
+    }
+
+    public void openHomeMenu(Player player) {
+        User user = essentials.getUser(player);
+        if (user == null) {
+            player.sendMessage("§cDeine Daten konnten nicht aus Essentials geladen werden.");
+            return;
+        }
+
+        Set<String> homes = user.getHomes();
+        if (homes.isEmpty()) {
+            player.sendMessage("§eDu hast noch keine Homes gesetzt.");
+            return;
+        }
+
+        List<String> sortedHomes = new ArrayList<>(homes);
+        Collections.sort(sortedHomes, String.CASE_INSENSITIVE_ORDER);
+
+        int size = ((sortedHomes.size() - 1) / 9 + 1) * 9;
+        size = Math.min(Math.max(size, 9), 54);
+        Inventory inventory = Bukkit.createInventory(player, size, "§8§lDeine Homes");
+
+        for (int i = 0; i < sortedHomes.size() && i < size; i++) {
+            String homeName = sortedHomes.get(i);
+            ItemStack item = createHomeItem(homeName, user);
+            inventory.setItem(i, item);
+        }
+
+        openMenus.put(player.getUniqueId(), inventory);
+        player.openInventory(inventory);
+    }
+
+    private ItemStack createHomeItem(String homeName, User user) {
+        ItemStack item = new ItemStack(Material.ENDER_PEARL);
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName("§b" + homeName);
+            List<String> lore = new ArrayList<>();
+            try {
+                Location location = user.getHome(homeName);
+                lore.add(String.format("§7Welt: §f%s", location.getWorld() != null ? location.getWorld().getName() : "Unbekannt"));
+                lore.add(String.format("§7X: §f%.1f §7Y: §f%.1f §7Z: §f%.1f", location.getX(), location.getY(), location.getZ()));
+            } catch (Exception ignored) {
+                lore.add("§cOrt konnte nicht geladen werden.");
+            }
+            meta.setLore(lore);
+            meta.addItemFlags(ItemFlag.values());
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+
+    public void handleMenuClick(Player player, int slot) {
+        Inventory inventory = openMenus.get(player.getUniqueId());
+        if (inventory == null) {
+            return;
+        }
+
+        if (slot < 0 || slot >= inventory.getSize()) {
+            return;
+        }
+
+        ItemStack item = inventory.getItem(slot);
+        if (item == null || !item.hasItemMeta() || item.getItemMeta() == null || !item.getItemMeta().hasDisplayName()) {
+            return;
+        }
+
+        String displayName = item.getItemMeta().getDisplayName();
+        String homeName = displayName.replace("§b", "").trim();
+
+        User user = essentials.getUser(player);
+        if (user == null) {
+            player.sendMessage("§cEssentials Daten nicht gefunden.");
+            return;
+        }
+
+        try {
+            Location homeLocation = user.getHome(homeName);
+            if (homeLocation == null) {
+                player.sendMessage("§cDieses Home existiert nicht mehr.");
+                return;
+            }
+            player.closeInventory();
+            player.teleport(homeLocation);
+            player.sendMessage("§aTeleportiere zu §f" + homeName + "§a.");
+        } catch (InvalidWorldException e) {
+            player.sendMessage("§cDie Welt für dieses Home existiert nicht.");
+        } catch (Exception e) {
+            player.sendMessage("§cTeleport fehlgeschlagen: " + e.getMessage());
+        }
+    }
+
+    public boolean isHomeMenu(Player player, Inventory inventory) {
+        if (inventory == null) {
+            return false;
+        }
+        Inventory openMenu = openMenus.get(player.getUniqueId());
+        return openMenu != null && openMenu.equals(inventory);
+    }
+
+    public void closeMenu(Player player) {
+        openMenus.remove(player.getUniqueId());
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,0 +1,15 @@
+name: HomeSystem
+main: de.example.homesystem.HomeSystemPlugin
+version: 1.0.0
+api-version: 1.20
+authors:
+  - ChatGPT
+softdepend:
+  - Essentials
+commands:
+  home:
+    description: Öffnet das Home Menü.
+    usage: /home
+  homes:
+    description: Öffnet das Home Menü.
+    usage: /homes


### PR DESCRIPTION
## Summary
- set up a Maven-based Spigot plugin project for an Essentials-powered home GUI
- implement commands and listeners that open a non-interactable inventory menu for teleporting to Essentials homes
- document installation, usage, and build steps in the README

## Testing
- `mvn -q -DskipTests package` *(fails: Maven Central returned 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68d8f00c289c832e978f66aedee5953d