### PR TITLE
Fix Maven build for offline environment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.resolver.transport>wagon</maven.resolver.transport>
     </properties>
 
     <repositories>
@@ -27,6 +28,13 @@
             <url>https://jitpack.io</url>
         </repository>
     </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>central</id>
+            <url>https://repo1.maven.org/maven2</url>
+        </pluginRepository>
+    </pluginRepositories>
 
     <dependencies>
         <dependency>
@@ -45,6 +53,11 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.0.2</version>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
## Summary
- configure Maven to use the wagon HTTP transport so artifact downloads work in restricted networks
- add an explicit plugin repository definition for Maven Central
- pin the Maven resources plugin version used during the build

## Testing
- `mvn -q -DskipTests package` *(fails: Maven Central returns HTTP 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d96e92947c832eabcbea54a7a62fc1